### PR TITLE
Session5

### DIFF
--- a/Yumemi-iOS-Training/Model/APIClient.swift
+++ b/Yumemi-iOS-Training/Model/APIClient.swift
@@ -9,7 +9,12 @@ import Foundation
 import YumemiWeather
 
 enum APIClient {
-    static func fetchWeatherCondition() -> String {
-        YumemiWeather.fetchWeatherCondition()
+    static func fetchWeatherCondition(completion: @escaping (Result<String,  YumemiWeatherError>) -> Void) {
+        do {
+            let result = try YumemiWeather.fetchWeatherCondition(at: "tokyo")
+            completion(.success(result))
+        } catch {
+            completion(.failure(.unknownError))
+        }
     }
 }

--- a/Yumemi-iOS-Training/Model/WeatherDelegate.swift
+++ b/Yumemi-iOS-Training/Model/WeatherDelegate.swift
@@ -8,5 +8,7 @@
 import Foundation
 
 protocol WeatherDelegate: AnyObject {
-    func updateWeather(_ fetchedWeatherCondition: String)
+    func updateWeather(_ fetchedWetherCondition: String)
+    func showNoWeatherResult(_ fetchedWetherCondition: String)
+    func showNoWeatherAlert()
 }

--- a/Yumemi-iOS-Training/Model/WeatherManager.swift
+++ b/Yumemi-iOS-Training/Model/WeatherManager.swift
@@ -11,7 +11,16 @@ final class WeatherManager {
     weak var delegate: WeatherDelegate? = nil
 
     func requestWeatherForecast() {
-        let fetchedWeatherCondition = APIClient.fetchWeatherCondition()
-        self.delegate?.updateWeather(fetchedWeatherCondition)
+        APIClient.fetchWeatherCondition(completion: {[weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let weatherResult):
+                let fetchedWetherCondition = weatherResult
+                self.delegate?.updateWeather(fetchedWetherCondition)
+            case .failure(let error):
+                print(error)
+            }
+        })
     }
 }

--- a/Yumemi-iOS-Training/Model/WeatherManager.swift
+++ b/Yumemi-iOS-Training/Model/WeatherManager.swift
@@ -13,12 +13,15 @@ final class WeatherManager {
     func requestWeatherForecast() {
         APIClient.fetchWeatherCondition(completion: {[weak self] result in
             guard let self = self else { return }
+            var fetchedWetherCondition = ""
 
             switch result {
             case .success(let weatherResult):
-                let fetchedWetherCondition = weatherResult
+                fetchedWetherCondition = weatherResult
                 self.delegate?.updateWeather(fetchedWetherCondition)
             case .failure(let error):
+                self.delegate?.showNoWeatherResult(fetchedWetherCondition)
+                self.delegate?.showNoWeatherAlert()
                 print(error)
             }
         })

--- a/Yumemi-iOS-Training/WeatherViewController.swift
+++ b/Yumemi-iOS-Training/WeatherViewController.swift
@@ -50,7 +50,6 @@ extension WeatherViewController: WeatherDelegate {
     func showNoWeatherResult(_ fetchedWetherCondition: String) {
         weatherImageView.image = UIImage(systemName: "questionmark.circle")?.withRenderingMode(.alwaysTemplate)
         weatherImageView.tintColor = .black
-        displayedWetherCondition = fetchedWetherCondition
     }
 
     func showNoWeatherAlert() {

--- a/Yumemi-iOS-Training/WeatherViewController.swift
+++ b/Yumemi-iOS-Training/WeatherViewController.swift
@@ -43,8 +43,20 @@ extension WeatherViewController: WeatherDelegate {
             weatherImageView.image = UIImage(named: "cloudy")?.withRenderingMode(.alwaysTemplate)
             weatherImageView.tintColor = .gray
         default:
-            weatherImageView.image = UIImage(systemName: "questionmark.circle")?.withRenderingMode(.alwaysTemplate)
-            weatherImageView.tintColor = .black
+            break
         }
+    }
+
+    func showNoWeatherResult(_ fetchedWetherCondition: String) {
+        weatherImageView.image = UIImage(systemName: "questionmark.circle")?.withRenderingMode(.alwaysTemplate)
+        weatherImageView.tintColor = .black
+        displayedWetherCondition = fetchedWetherCondition
+    }
+
+    func showNoWeatherAlert() {
+        let noWeatherAlert = UIAlertController(title: "天気を読み込めませんでした", message: nil, preferredStyle: .actionSheet)
+        let closeAction = UIAlertAction(title: "閉じる", style: .default)
+        noWeatherAlert.addAction(closeAction)
+        present(noWeatherAlert, animated: true, completion: nil)
     }
 }

--- a/Yumemi-iOS-Training/WeatherViewController.swift
+++ b/Yumemi-iOS-Training/WeatherViewController.swift
@@ -34,13 +34,13 @@ extension WeatherViewController: WeatherDelegate {
     func updateWeather(_ fetchedWeatherCondition: String) {
         switch fetchedWeatherCondition {
         case "sunny":
-            weatherImageView.image = UIImage(named: "sunny")?.withRenderingMode(.alwaysTemplate)
+            weatherImageView.image = #imageLiteral(resourceName: "sunny").withRenderingMode(.alwaysTemplate)
             weatherImageView.tintColor = .red
         case "rainy":
-            weatherImageView.image = UIImage(named: "rainy")?.withRenderingMode(.alwaysTemplate)
+                        weatherImageView.image = #imageLiteral(resourceName: "rainy").withRenderingMode(.alwaysTemplate)
             weatherImageView.tintColor = .blue
         case "cloudy":
-            weatherImageView.image = UIImage(named: "cloudy")?.withRenderingMode(.alwaysTemplate)
+                        weatherImageView.image = #imageLiteral(resourceName: "cloudy").withRenderingMode(.alwaysTemplate)
             weatherImageView.tintColor = .gray
         default:
             break


### PR DESCRIPTION
# Error

Xcode14.2を使用
（参考UIはiPhone 14 Pro）

## 課題リンク
https://github.com/yumemi-inc/ios-training/blob/main/Documentation/Error.md

## 仕様
- fetchWeatherConditionをthrow verに変更しました
- APIClient、WeatherManagerをエラーハンドリングできるように対応しました
- WeatherManagerでエラーの場合、アラートを呼ぶようにしました
- areaは指定されていないので、一旦YumemiWeather.fetchWeatherCondition(at: "tokyo")のように"tokyo"としました

## 対応内容
[9a14901cd396958db9670b9f8a66c5133b010eac]APIをthrow verに変更
[2b9cce6657e8093522d42fb9db1941ad245e3a00]アラート追加
[9bfcb91b40b4eae56fd02349aaefc61e5bfa4f57] #3 で頂いたレビューの通り、画像を#imageLiteralに変更
[4b0e89475163f8ddc6441d730577810cf8d1e817] rebaseのときに残ってしまったものの修正


## UI差分

https://user-images.githubusercontent.com/83959618/209038618-2e0cdb00-8c1c-4f0b-b14e-4719ed99a5bc.mp4

## チェック項目
- [x] 呼び出しAPIをThrows verに変更する
- [x] エラーを Delegate で受け取る
- [x] 天気予報を画面に表示する
- [x] APIエラーが発生したらUIAlertControllerを表示する