### PR TITLE
Session8

### DIFF
--- a/Yumemi-iOS-Training/WeatherViewController.swift
+++ b/Yumemi-iOS-Training/WeatherViewController.swift
@@ -21,6 +21,12 @@ final class WeatherViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         weatherManager.delegate = self
+
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(foreground(notification:)),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil
+        )
     }
 
     @IBAction private func reloadButtonPressed(_ sender: Any) {
@@ -43,6 +49,10 @@ final class WeatherViewController: UIViewController {
         let closeAction = UIAlertAction(title: "閉じる", style: .default)
         noWeatherAlert.addAction(closeAction)
         present(noWeatherAlert, animated: true)
+    }
+
+    @objc private func foreground(notification: Notification) {
+        weatherManager.requestWeatherForecast()
     }
 }
 


### PR DESCRIPTION
# NotificationCenter

Xcode14.2を使用
（参考UIはiPhone 14 Pro）

## 課題リンク
https://github.com/yumemi-inc/ios-training/blob/main/Documentation/NotificationCenter.md

## 仕様
- バックグラウンドからフォアグラウンドへ戻った際に、WeatherManagerを呼び出す

## 対応内容
[559d5552614cb582bb8fadf7197d92b71828a8ca] 

## UI差分

https://user-images.githubusercontent.com/83959618/209496727-e24404c2-6f26-45e4-b061-92824d73214a.mov

## チェック項目
- [x] NotificationCenterを利用して、アプリがバックグラウンドからフォアグラウンドに戻ってきたときに、天気予報を更新する